### PR TITLE
Refactor to make it easy to add configuration updating

### DIFF
--- a/lua/config.lua
+++ b/lua/config.lua
@@ -39,21 +39,9 @@ local function validate_config(config)
   end
 end
 
-local function set_colorscheme_callbacks()
-  if Config.mode == 'colorscheme' then
-    Config.light_mode_callback = function()
-      vim.cmd({cmd = 'colorscheme', args = { Config.light_mode_colorscheme } } )
-    end
-    Config.dark_mode_callback = function()
-      vim.cmd({cmd = 'colorscheme', args = { Config.dark_mode_colorscheme } } )
-    end
-  end
-end
-
 M.load = function(new_config)
   if pcall(function() validate_config(new_config) end) then
     merge(Config, new_config)
-    set_colorscheme_callbacks()
   end
 end
 

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,0 +1,64 @@
+local M = {}
+
+local Config = {
+  mode = 'background',
+  dark_mode_callback = function() end,
+  light_mode_callback = function() end,
+}
+
+local function merge(t1, t2)
+  for k, v in pairs(t2) do
+    if (type(v) == "table") and (type(t1[k] or false) == "table") then
+      merge(t1[k], t2[k])
+    else
+      t1[k] = v
+    end
+  end
+  return t1
+end
+
+local function validate_config(config)
+  if config.mode == 'background' then
+    return true
+  elseif config.mode == 'colorscheme' then
+    if config.light_mode_colorscheme == nil then
+      error("DarkLight: option light_mode_colorscheme is required for colorscheme mode\nFalling back to background mode")
+    end
+    if config.dark_mode_colorscheme == nil then
+      error("DarkLight: option dark_mode_colorscheme is required for colorscheme mode\nFalling back to background mode")
+    end
+  elseif config.mode == 'custom' then
+    if config.light_mode_callback == nil then
+      error("DarkLight: option light_mode_callback is required for custom mode\nFalling back to background mode")
+    end
+    if config.dark_mode_callback == nil then
+      error("DarkLight: option dark_mode_callback is required for custom mode\nFalling back to background mode")
+    end
+  else
+    error("DarkLight: invalid option `mode`; Falling back to background mode")
+  end
+end
+
+local function set_colorscheme_callbacks()
+  if Config.mode == 'colorscheme' then
+    Config.light_mode_callback = function()
+      vim.cmd({cmd = 'colorscheme', args = { Config.light_mode_colorscheme } } )
+    end
+    Config.dark_mode_callback = function()
+      vim.cmd({cmd = 'colorscheme', args = { Config.dark_mode_colorscheme } } )
+    end
+  end
+end
+
+M.load = function(new_config)
+  if pcall(function() validate_config(new_config) end) then
+    merge(Config, new_config)
+    set_colorscheme_callbacks()
+  end
+end
+
+M.current = function()
+  return Config
+end
+
+return M

--- a/lua/darklight.lua
+++ b/lua/darklight.lua
@@ -21,10 +21,10 @@ local Config = {
 local function set_colorscheme_callbacks()
   if Config.mode == 'colorscheme' then
     Config.light_mode_callback = function()
-      vim.api.nvim_exec("colorscheme " .. Config.light_mode_colorscheme, false)
+      vim.cmd({cmd = 'colorscheme', args = { Config.light_mode_colorscheme } } )
     end
     Config.dark_mode_callback = function()
-      vim.api.nvim_exec("colorscheme " .. Config.dark_mode_colorscheme, false)
+      vim.cmd({cmd = 'colorscheme', args = { Config.dark_mode_colorscheme } } )
     end
   end
 end

--- a/lua/darklight.lua
+++ b/lua/darklight.lua
@@ -1,74 +1,19 @@
 local M = {}
-
--- utilities
-local function merge(t1, t2)
-  for k, v in pairs(t2) do
-    if (type(v) == "table") and (type(t1[k] or false) == "table") then
-      merge(t1[k], t2[k])
-    else
-      t1[k] = v
-    end
-  end
-  return t1
-end
-
-local Config = {
-  mode = 'background',
-  dark_mode_callback = function() end,
-  light_mode_callback = function() end,
-}
-
-local function set_colorscheme_callbacks()
-  if Config.mode == 'colorscheme' then
-    Config.light_mode_callback = function()
-      vim.cmd({cmd = 'colorscheme', args = { Config.light_mode_colorscheme } } )
-    end
-    Config.dark_mode_callback = function()
-      vim.cmd({cmd = 'colorscheme', args = { Config.dark_mode_colorscheme } } )
-    end
-  end
-end
-
-local function validate_config(config)
-  if config.mode == 'background' then
-    return true
-  elseif config.mode == 'colorscheme' then
-    if config.light_mode_colorscheme == nil then
-      error("DarkLight: option light_mode_colorscheme is required for colorscheme mode\nFalling back to background mode")
-    end
-    if config.dark_mode_colorscheme == nil then
-      error("DarkLight: option dark_mode_colorscheme is required for colorscheme mode\nFalling back to background mode")
-    end
-  elseif config.mode == 'custom' then
-    if config.light_mode_callback == nil then
-      error("DarkLight: option light_mode_callback is required for custom mode\nFalling back to background mode")
-    end
-    if config.dark_mode_callback == nil then
-      error("DarkLight: option dark_mode_callback is required for custom mode\nFalling back to background mode")
-    end
-  else
-    error("DarkLight: invalid option `mode`; Falling back to background mode")
-  end
-end
-
--- Public API
+local Config = require('config')
 
 M.color_switch = function()
   local currentColor = vim.go.background
   if currentColor == 'dark' then
-    Config.light_mode_callback()
+    Config.current().light_mode_callback()
     vim.go.background = 'light'
   else
-    Config.dark_mode_callback()
+    Config.current().dark_mode_callback()
     vim.go.background = 'dark'
   end
 end
 
 M.setup = function(config)
-  if pcall(function() validate_config(config) end) then
-    merge(Config, config)
-    set_colorscheme_callbacks()
-  end
+  Config.load(config)
 
   local user_create_cmd = vim.api.nvim_create_user_command
 


### PR DESCRIPTION
## Refactor colorswitching to use vim.cmd
Using nvim_exec requires doing some string interpolation, whereas
`vim.cmd` takes a structure table for the command. This makes the code a
little cleaner and easier to understand.

## Refactor Configuration
Extracted the Configuration into its own module so that it's better
separated from the external interface. This will let me start to make
the configuration a bit more modular/updatable.